### PR TITLE
fix: laptop and mobile layout are now readable and usable easily

### DIFF
--- a/frontend/src/css/Home.css
+++ b/frontend/src/css/Home.css
@@ -53,6 +53,20 @@
 }
 
 
+
+
+.movies-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+  padding: 1rem;
+  width: 100%;
+  box-sizing: border-box;
+  justify-content: center;
+}
+
+/* Media Queries for smaller screens */
+
 @media (max-width: 639px) {
   .home {
     padding: 1rem 0;
@@ -62,18 +76,6 @@
     margin-bottom: 1rem;
   }
 }
-
-.movies-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(130px, 180px));
-  gap: 1.5rem;
-  padding: 1rem;
-  width: 100%;
-  box-sizing: border-box;
-  justify-content: start;
-}
-
-/* Media Queries for smaller screens */
 
 @media (max-width: 768px) {
   .movies-grid {


### PR DESCRIPTION
Changed the grid back to `grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));` and `justify-content: center;` but added media queries for mobile.

close #48 